### PR TITLE
Add in authenication for Android #2

### DIFF
--- a/components/SignIn.js
+++ b/components/SignIn.js
@@ -40,7 +40,7 @@ class SignIn extends Component {
   render() {
     return (
       <View style={ styles.container }>
-        <TextInput autoCapitalize='none' style={ styles.email } value={ this.state.username } placeholder="Email" onChangeText={ (username) => this.setState({username}) } />
+        <TextInput underlineColorAndroid='transparent' autoCapitalize='none' style={ styles.email } value={ this.state.username } placeholder="Email" onChangeText={ (username) => this.setState({username}) } />
         <TextInput style={ styles.password } value={ this.state.password }  placeholder="Password" onChangeText={ (password) => this.setState({password}) } secureTextEntry={ true }/>
         <Button onPress={ this.attemptLogin } title="Sign In" color="#FDD835"/>
         <View style={{ flexDirection: 'row' }}>
@@ -63,21 +63,27 @@ const styles = StyleSheet.create({
   },
 
   email: {
-    height: 40,
+    alignSelf: 'stretch',
     borderColor: '#E0E0E0',
     borderWidth: 1,
     borderRadius: 3,
+    height: 40,
+    fontSize: 13,
     marginBottom: 10,
-    paddingLeft: 10
+    paddingLeft: 10,
+    textAlign: 'center'
   },
 
   password: {
-    height: 40,
+    alignSelf: 'stretch',
     borderColor: '#E0E0E0',
     borderWidth: 1,
     borderRadius: 3,
+    fontSize: 13,
+    height: 40,
     marginBottom: 10,
-    paddingLeft: 10
+    paddingLeft: 10,
+    textAlign: 'center'
   },
 
   yellowFont: {

--- a/components/SignUp.js
+++ b/components/SignUp.js
@@ -63,21 +63,27 @@ const styles = StyleSheet.create({
   },
 
   email: {
+    alignSelf: 'stretch',
     height: 40,
     borderColor: '#E0E0E0',
     borderWidth: 1,
     borderRadius: 3,
     marginBottom: 10,
-    paddingLeft: 10
+    fontSize: 13,
+    paddingLeft: 10,
+    textAlign: 'center'
   },
 
   password: {
+    alignSelf: 'stretch',
     height: 40,
     borderColor: '#E0E0E0',
     borderWidth: 1,
     borderRadius: 3,
     marginBottom: 10,
-    paddingLeft: 10
+    fontSize: 13,
+    paddingLeft: 10,
+    textAlign: 'center'
   },
 
   yellowFont: {

--- a/index.android.js
+++ b/index.android.js
@@ -5,28 +5,62 @@
  */
 
 import React, { Component } from 'react';
-import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
+import { AppRegistry, Alert, StyleSheet, Text, View } from 'react-native';
+import * as firebase from 'firebase';
+import SignIn from './components/SignIn'
+import SignUp from './components/SignUp'
+
+//Initialize Firebase
+const firebaseConfig = {
+  apiKey: "AIzaSyCdndiS6rlCzlORIn5oQ4m5oPL9jsV0AhE",
+  authDomain: "destination-delicious.firebaseapp.com",
+  databaseURL: "https://destination-delicious.firebaseio.com",
+  projectId: "destination-delicious",
+  storageBucket: "destination-delicious.appspot.com",
+ messagingSenderId: "26242783843"
+}
+
+const firebaseApp = firebase.initializeApp(firebaseConfig)
 
 export default class destinationDelicious extends Component {
+  constructor() {
+    super()
+    this.state = {
+      signUp: false
+    }
+  }
+
+  verifyAuthState = (verify) => {
+    this.setState({
+      signUp: verify
+    })
+  }
+
+  checkSignIn() {
+    if(this.state.signUp === true) {
+      return (
+        <View style={styles.container}>
+          <Text style={ styles.welcome }>
+          Welcome to Destination Delicious!
+          </Text>
+          <SignUp firebase={ firebaseApp } verifyAuthState={ this.verifyAuthState } />
+        </View>
+      )
+    } else {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.welcome}>
+            Welcome to Destination Delicious!
+          </Text>
+          <SignIn firebase={ firebaseApp } verifyAuthState={ this.verifyAuthState } />
+        </View>
+      )
+    }
+  }
+
   render() {
     return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          To get started, edit index.android.js
-        </Text>
-        <Text style={styles.instructions}>
-          Double tap R on your keyboard to reload,{'\n'}
-          Shake or press menu button for dev menu
-        </Text>
-      </View>
+      this.checkSignIn()
     );
   }
 }
@@ -36,18 +70,14 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#F5FCFF',
+    backgroundColor: '#FFF',
   },
+
   welcome: {
     fontSize: 20,
     textAlign: 'center',
     margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
+  }
 });
 
 AppRegistry.registerComponent('destinationDelicious', () => destinationDelicious);


### PR DESCRIPTION
This now mirrors the iOS auth process. I added in another prop to the TextInput for some reason on Android the TextInputs rendered with an underline so I added in `underlineColorAndroid='transparent'` this doesn't affect iOS in any way.